### PR TITLE
Fix scope issue

### DIFF
--- a/src/hooks/useSubscription.tsx
+++ b/src/hooks/useSubscription.tsx
@@ -20,7 +20,6 @@ function useSubscription(
       'There must be a StompSessionProver as Ancestor of all Stomp Hooks and HOCs'
     );
 
-  const callbackRef = useRef<messageCallbackType>(onMessage);
   const _destinations = Array.isArray(destinations)
     ? destinations
     : [destinations];
@@ -33,7 +32,7 @@ function useSubscription(
         stompContext.subscribe(
           _destination,
           (message) => {
-            callbackRef.current(message);
+            onMessage(message);
           },
           headers
         )
@@ -45,7 +44,7 @@ function useSubscription(
         _cleanUpFunction();
       });
     };
-  }, [...Object.values(_destinations), ...Object.values(headers)]);
+  }, [...Object.values(_destinations), onMessage, ...Object.values(headers)]);
 }
 
 export default useSubscription;

--- a/src/hooks/useSubscription.tsx
+++ b/src/hooks/useSubscription.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef } from 'react';
+import { useContext, useEffect } from 'react';
 import StompContext from '../context/StompContext';
 import { messageCallbackType, StompHeaders } from '@stomp/stompjs';
 


### PR DESCRIPTION
Hello,
The issue I am having is if I do the following:

```useSubscription([`/topic/user-${user.id}-notifications`], onMessage)```

If onMessage uses any value that changes, it does not update inside the function. The onMessage function stores the first instance of itself.
I see the reason is setting the onMessage function into a useRef. Why was the reason this was done?

This PR should fix this if there is no underlying reason for this